### PR TITLE
Re-add "copied from XXX"

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -17,7 +17,7 @@
       "instance_type": "t2.medium",
       "encrypt_boot": true,
       "user_data_file": "./scripts/reseal",
-      "ami_name": "{{user `ami_name`}}"
+      "ami_name": "{{user `ami_name`}} copied from {{user `source_ami`}}"
     }
   ]
 }


### PR DESCRIPTION
Re-add "copied from XXX" because temporarily there are 2x AMIs and they cannot have the same name.