### PR TITLE
Now that we have migrated from Win2012R2 to Win1019 

### DIFF
--- a/scripts/reseal
+++ b/scripts/reseal
@@ -1,35 +1,8 @@
 <powershell>
-$EC2SettingsFile="C:\\Program Files\\Amazon\\Ec2ConfigService\\Settings\\Config.xml"
-$xml = [xml](get-content $EC2SettingsFile)
-$xmlElement = $xml.get_DocumentElement()
-$xmlElementToModify = $xmlElement.Plugins
+# $EC2LaunchExe="C:\\Program Files\\Amazon\\EC2Launch\\EC2Launch.exe"
+$EC2LaunchExe="$ENV:ProgramFiles\Amazon\EC2Launch\EC2Launch.exe"
 
-foreach ($element in $xmlElementToModify.Plugin)
-{
-    if ($element.name -eq "Ec2SetPassword")
-    {
-        $element.State="Enabled"
-    }
-    elseif ($element.name -eq "Ec2SetComputerName")
-    {
-        $element.State="Disabled"
-    }
-    elseif ($element.name -eq "Ec2HandleUserData")
-    {
-        $element.State="Enabled"
-    }
-}
-$xml.Save($EC2SettingsFile)
-$EC2SettingsFile="C:\\Program Files\\Amazon\\Ec2ConfigService\\Settings\\BundleConfig.xml"
-$xml = [xml](get-content $EC2SettingsFile)
-$xmlElement = $xml.get_DocumentElement()
+# & $EC2LaunchExe reset --clean --block
+& $EC2LaunchExe sysprep --clean --block
 
-foreach ($element in $xmlElement.Property)
-{
-    if ($element.Name -eq "AutoSysprep")
-    {
-        $element.Value="Yes"
-    }
-}
-$xml.Save($EC2SettingsFile)
 </powershell>


### PR DESCRIPTION
- we need to use EC2Launch-v2, not EC2Config syntax to reseal the images.