### PR TITLE
Feature/aws cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ RUN apk update \
        python3 \
        py3-pip\
        git \
-       openssh
-# Create and activate virtual environment, then install pipx, awscli & setuptools
-RUN python3 -m venv /opt/venv \
-    && /opt/venv/bin/pip install pipx awscli setuptools \
-    && rm -rf /var/cache/apk /root/.cache
+       openssh \
+    && pip install --no-cache-dir --upgrade pip setuptools \
+    && pip install --no-cache-dir awscli   
 
 RUN adduser -D packer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ RUN apk update \
        py3-pip\
        git \
        openssh \
-    && pip install --no-cache-dir --upgrade pip setuptools \
-    && pip install --no-cache-dir awscli   
+       aws-cli
+    # && pip install --no-cache-dir --upgrade pip setuptools \
+    # && pip install --no-cache-dir awscli   
 
 RUN adduser -D packer
 

--- a/build.sh
+++ b/build.sh
@@ -32,4 +32,8 @@ else
   packer_file="packer.json"
 fi
 
+echo "Installing required plugins before build"
+
+packer plugins install github.com/hashicorp/amazon
+
 packer build ${packer_file}


### PR DESCRIPTION
Install aws cli using package manager and install aws plugins before packer build.
Fixes problems from packer builds in other repositories where after version 1.10+ plugins need to be installed separately and the aws-cli wasnt being picked up when installed in a virtual env